### PR TITLE
feat(metrics): improve status metrics and update prometheus rules

### DIFF
--- a/prometheus/status.rule
+++ b/prometheus/status.rule
@@ -6,10 +6,30 @@ groups:
       - alert: ProcessRestarted
         expr: changes(process_start_time_seconds{job="collaterals"}[15m]) >= 3
         labels:
-          stage: testing
-          severity: warning
+          severity: critical
         annotations:
           summary: Too much Maker bot restarts
-          description: The Maker bot has been restarted for {{ $value }} times for the last 15 minutes
+          description: >-
+            The Maker bot has been restarted for {{ $value }} times
+            for the last 15 minutes
+
+      - alert: StaleBotReport
+        expr: time() - makers_risks_processing_finished_seconds > 3600
+        labels:
+          severity: high
+        annotations:
+          summary: Stale bot report detected
+          description: >-
+            Last update for {{ .Labels.ilk }} was
+            {{ $value | humanizeDuration }} ago
+
+      - alert: MakerDataAPIOutdated
+        expr: |  # 1 hour
+          maker_risks_eth_latest_block_num - maker_risks_api_last_block_num
+          > 60 * 60 / 14
+        labels:
+          severity: high
+        annotations:
+          summary: Maker DataAPI is out of sync for {{ $value }} blocks
 
 # vim: set ts=2 sw=2 ft=yaml:

--- a/prometheus/status.test
+++ b/prometheus/status.test
@@ -14,11 +14,46 @@ tests:
         alertname: ProcessRestarted
         exp_alerts:
           - exp_labels:
-              severity: warning
-              stage: testing
+              severity: critical
               job: collaterals
             exp_annotations:
               summary: Too much Maker bot restarts
-              description: The Maker bot has been restarted for 3 times for the last 15 minutes
+              description: >-
+                The Maker bot has been restarted for 3 times
+                for the last 15 minutes
+
+  # StaleBotReport
+  - interval: 15m
+    input_series:
+      - series: makers_risks_processing_finished_seconds{ilk="wstETH_A"}
+        values: 900+0x10
+    alert_rule_test:
+      # event should fire
+      - eval_time: 1h30m
+        alertname: StaleBotReport
+        exp_alerts:
+          - exp_labels:
+              ilk: wstETH_A
+              severity: high
+            exp_annotations:
+              summary: Stale bot report detected
+              description: Last update for wstETH_A was 1h 15m 0s ago
+
+  # MakerDataAPIOutdated
+  - interval: 1m
+    input_series:
+      - series: maker_risks_eth_latest_block_num
+        values: 100+5x89
+      - series: maker_risks_api_last_block_num
+        values: 100+0x89
+    alert_rule_test:
+      # event should fire
+      - eval_time: 1h
+        alertname: MakerDataAPIOutdated
+        exp_alerts:
+          - exp_labels:
+              severity: high
+            exp_annotations:
+              summary: Maker DataAPI is out of sync for 300 blocks
 
 # vim: set ts=2 sw=2 ft=yaml:

--- a/src/bot/metrics.py
+++ b/src/bot/metrics.py
@@ -11,15 +11,18 @@ COLLATERALS_ZONES_PERCENT = Gauge(
     "Maker collaterals percentage distribution",
     ("ilk", "zone"),
 )
-PARSER_LAST_FETCHED = Gauge(
-    f"{PREFIX}_parser_last_fetched",
+PROCESSING_COMPLETED = Gauge(
+    f"{PREFIX}_processing_finished_seconds",
     "Last one successful parsing cycle completion timestamp",
     ("ilk",),
 )
-PARSER_LAST_BLOCK = Gauge(
-    f"{PREFIX}_parser_last_block",
-    "Last block available to fetch from Maker database",
-    ("ilk",),
+API_LAST_BLOCK = Gauge(
+    f"{PREFIX}_api_last_block_num",
+    "Last block number available to fetch from Maker database",
+)
+ETH_LATEST_BLOCK = Gauge(
+    f"{PREFIX}_eth_latest_block_num",
+    "Latest block block number fetched by bot",
 )
 FETCH_DURATION = Gauge(
     f"{PREFIX}_fetch_duration",

--- a/src/bot/parsers/makerapi.py
+++ b/src/bot/parsers/makerapi.py
@@ -73,6 +73,12 @@ class MakerAPIProvider:
         resp.raise_for_status()
         return resp.json()
 
+    def last_block(self) -> int:
+        """Retrieve the number of the latest synchronised block"""
+
+        req = self.get("/state/last_block")
+        return req["last_block"]
+
 
 class MakerAPIParser(BaseParser):
     """Maker protocol parser based on Maker Data API"""
@@ -80,12 +86,6 @@ class MakerAPIParser(BaseParser):
     def __init__(self, asset: MakerCollateral, api: MakerAPIProvider) -> None:
         super().__init__(asset)
         self._api = api
-
-    def fetch_block(self) -> int:
-        """Retrieve the id of the latest synchronised block"""
-
-        req = self._api.get("/state/last_block")
-        return req["last_block"]
 
     def get_urns(self) -> Iterable:
         """Get data from Maker Data API"""
@@ -110,7 +110,7 @@ class MakerAPIParser(BaseParser):
         return out
 
     def parse(self) -> pd.DataFrame:
-        self.block = self.fetch_block()
+        self.block = self._api.last_block()
         log.info("fetching data for %s ilk from block %d", self.asset.symbol, self.block)
 
         df = pd.DataFrame(self.get_urns())


### PR DESCRIPTION
A few status alerts added:
1. `StaleBotReport` which triggers if the last report is older than 1 hour.
2. `MakerDataAPIOutdated` which indicates gap in API index.