### PR TITLE
fix: use loan value round

### DIFF
--- a/prometheus/zones_changes.rule
+++ b/prometheus/zones_changes.rule
@@ -15,7 +15,7 @@ groups:
           description: >-
             It is {{ $value | printf "%.1f" }}% (
             {{- with printf "sum(maker_risks_collateral_value{zone=~'C|D|liquidation',ilk=%q})" .Labels.ilk | query -}}
-            {{- . | first | value -}}
+            {{- . | first | value | printf "%.1f" -}}
             {{- end }}
             {{ .Labels.ilk }})
             of total {{ .Labels.ilk }}-collateral on Maker in risky zone!

--- a/prometheus/zones_changes.test
+++ b/prometheus/zones_changes.test
@@ -13,7 +13,7 @@ tests:
       - series: maker_risks_collateral_value{zone="D", ilk="wstETH"}
         values: 20+0x10
       - series: maker_risks_collateral_value{zone="liquidation", ilk="wstETH"}
-        values: 2+0x10
+        values: 2.31415926+0x10
     alert_rule_test:
       # no fire
       - eval_time: 5m
@@ -27,7 +27,7 @@ tests:
               ilk: wstETH
             exp_annotations:
               summary: High percent of Maker wstETH in dangerous zone 🔥
-              description: It is 20.0% (42 wstETH) of total wstETH-collateral on Maker in risky zone!
+              description: It is 20.0% (42.3 wstETH) of total wstETH-collateral on Maker in risky zone!
 
   # MakerCollateralsLiquidation
   - interval: 5m


### PR DESCRIPTION
Avoid these kinds of alerts:

```
It is 15.5% (154.11647659507122 steCRV_A) of total steCRV_A-collateral on Maker in risky zone!
```